### PR TITLE
Fixes to order that styles are applied in order to prevent loss of scroll position

### DIFF
--- a/jquery.masonry.js
+++ b/jquery.masonry.js
@@ -187,7 +187,8 @@
         // fit container to columns that have been used;
         containerSize.width = (this.cols - unusedCols) * this.columnWidth - this.options.gutterWidth;
       }
-      this.styleQueue.push({ $el: this.element, style: containerSize });
+      // push the container style to the start of the queue
+      this.styleQueue = [{ $el: this.element, style: containerSize }].concat(this.styleQueue);
 
       // are we animating the layout arrangement?
       // use plugin-ish syntax for css or animate


### PR DESCRIPTION
There were two problems that I tried to fix.

1) _getBricks was going beyond its name and making all the bricks position absolute and bypassing the style queue. This meant that there was a brief moment where the container had a height of 0 and so there was a slight loss of scroll position when using the back button. The amount of loss depended on how far down the page you were and could get quite severe.

2) The style queue was setting the container height last. In the real world the style queue is processed so fast that it doesn't seem to make a difference what order it's done in but I think it is more sensible to set the container height first to prevent any loss of scroll position.

3) I didn't mean to kill your newline.
