### PR TITLE
Reduced wasted space, made wasted space useful, more sensical item ordering, events.

### DIFF
--- a/jquery.masonry.js
+++ b/jquery.masonry.js
@@ -244,7 +244,8 @@
     // i.e. this.columnWidth = 200
     _getColumns : function() {
       var container = this.options.isFitWidth ? this.element.parent() : this.element,
-          containerWidth = container.width();
+          containerWidth = container.width(),
+          containerPadding = this.element.outerWidth() - this.element.width();
 
                          // use fluid columnWidth function if there
       this.columnWidth = this.isFluid ? this.options.columnWidth( containerWidth ) :
@@ -257,7 +258,7 @@
 
       this.columnWidth += this.options.gutterWidth;
 
-      this.cols = Math.floor( ( containerWidth + this.options.gutterWidth ) / this.columnWidth );
+      this.cols = Math.floor( ( containerWidth + this.options.gutterWidth - containerPadding ) / this.columnWidth );
       this.cols = Math.max( this.cols, 1 );
 
     },


### PR DESCRIPTION
I have been working with masonry trying to reduce the amount of space that is left blank, make the elements appear in a more sensical, left to right, order, and to make wasted space more useful. It might make sense to divide this into multiple pull requests, but I don't know how to do that, or if it's even possible.
#### Reducing the amount of wasted space

Before placing a block, it will look at how much space is wasted with each placement option and choose the one that wastes the least. A jitter amount can be set in the options (options.wastedSpaceJitter) to allow it to place the block higher or further to the left if the amount of wasted space is small enough, rather than just placing it where wasted space is smallest. This reduces the wasted space by about 50% but can occasionally cause columns of whitespace at the bottom.
#### Making wasted space useful

A new event, masonry.wastedspace, is triggered whenever masonry is about place a brick with wasted space above, and when masonry is finished. The second argument to the callback is an array of objects with top, left (or right), width, and height properties for each column of wasted space.
#### Putting items in a more sensical order

A second jitter value was added to the options (options.yJitter) to allow the placement of an element further to the left if the difference between the y value of two placement options is small enough. This prevents situations where block 8 is placed to the right of block 9 because that column was 1 pixel higher.
#### Events
- masonry.wastedspace
- masonry.beforelayout
- masonry.complete
