### PR TITLE
It fixes the compatibility with jQuery 1.9

### DIFF
--- a/jquery.masonry.js
+++ b/jquery.masonry.js
@@ -45,7 +45,7 @@
 
       if ( resizeTimeout ) { clearTimeout( resizeTimeout ); }
       resizeTimeout = setTimeout(function() {
-        $.event.handle.apply( context, args );
+        $.event[$.event.handle ? "handle" : "trigger"].apply( context, args );
       }, execAsap === "execAsap"? 0 : 100 );
     }
   };


### PR DESCRIPTION
It seems that masonry does not work with jQuery 1.9 because $.event.handle returns undefined
