### PR TITLE
don't layout if Masonry has been destroyed

### DIFF
--- a/masonry.js
+++ b/masonry.js
@@ -173,6 +173,10 @@ function masonryDefinition( Outlayer, getSize ) {
   // HEADS UP this overwrites Outlayer.resize
   // Any changes in Outlayer.resize need to be manually added here
   Masonry.prototype.resize = function() {
+    // If Masonry has been destroyed, don't do anything
+    if (this.element.outlayerGUID === undefined) {
+       return;
+    }
     // don't trigger if size did not change
     var container = this._getSizingContainer();
     var size = getSize( container );


### PR DESCRIPTION
If programmer destroys Masonry by his own window.resize function, Masonry often will fire layout() anyway because of its own debounced resize handler event. This change exits the resize function if it detects that the outlayerGUID property has been deleted already.
