### PR TITLE
Prevent delayed resize after destroy, fixes #252

### DIFF
--- a/masonry.js
+++ b/masonry.js
@@ -175,6 +175,9 @@ function masonryDefinition( Outlayer, getSize ) {
   // HEADS UP this overwrites Outlayer.resize
   // Any changes in Outlayer.resize need to be manually added here
   Masonry.prototype.resize = function() {
+	if (!this.isResizeBound) {
+		return;
+	}
     // don't trigger if size did not change
     var previousWidth = this.containerWidth;
     this.getContainerWidth();


### PR DESCRIPTION
Due to onresize setting a timeout to run the resize method after a delay
of 100ms, it will still be run even after using the destroy method,
because unbinding the resize method doesn't help prevent already
scheduled functions from running. This fix should prevent this from
happening.
