### PR TITLE
Add the reload method for backwards compatibility

### DIFF
--- a/examples/js/masonry-v2-shim.js
+++ b/examples/js/masonry-v2-shim.js
@@ -71,4 +71,8 @@
     _measureColumns.apply( this, arguments );
   };
 
+  Masonry.prototype.reload = function() {
+    this.reloadItems.apply( this, arguments );
+  };
+
 })( window );


### PR DESCRIPTION
Looks like `.reload()` or `.masonry( 'reload' )` is used fairly often, especially among some WordPress themes that support infinite scroll. It would be nice to keep supporting the method in the shim.
