### PR TITLE
Call layout() in the reload() back-compat method for consistent behavior with v2

### DIFF
--- a/examples/js/masonry-v2-shim.js
+++ b/examples/js/masonry-v2-shim.js
@@ -73,6 +73,7 @@
 
   Masonry.prototype.reload = function() {
     this.reloadItems.apply( this, arguments );
+    this.layout.apply( this );
   };
 
 })( window );


### PR DESCRIPTION
As discussed here #531.
