### PR TITLE
Fixes layout calculation problems for Firefox and Safari

### DIFF
--- a/masonry.js
+++ b/masonry.js
@@ -79,7 +79,8 @@ function masonryDefinition( Outlayer, getSize ) {
   Masonry.prototype._getItemLayoutPosition = function( item ) {
     item.getSize();
     // how many columns does this brick span
-    var remainder = item.size.outerWidth % this.columnWidth;
+    var factor = item.size.outerWidth / this.columnWidth,
+    	remainder = factor - Math.floor( factor );
     var mathMethod = remainder && remainder < 1 ? 'round' : 'ceil';
     // round if off by 1 pixel, otherwise use ceil
     var colSpan = Math[ mathMethod ]( item.size.outerWidth / this.columnWidth );

--- a/masonry.js
+++ b/masonry.js
@@ -63,7 +63,7 @@ function masonryDefinition( Outlayer, getSize ) {
 
     this.columnWidth += this.gutter;
 
-    this.cols = Math.floor( ( this.containerWidth + this.gutter ) / this.columnWidth );
+    this.cols = Math.round( ( this.containerWidth + this.gutter ) / this.columnWidth );
     this.cols = Math.max( this.cols, 1 );
   };
 


### PR DESCRIPTION
In Firefox the this.gutter value is sometimes a bit different. That causes in some use cases a this.cols calculation result lower than the expected. Using Math.round instead of Math.floor fixes this problem here and outputs the correct this.cols value.

There was a problem in calculation of the colSpan:
Firefox: operator % produces in some cases results > "1"
Safari: operator % produces in some cases "1" as result