### PR TITLE
explicitly states that gutterWidth units are pixels

### DIFF
--- a/_posts/docs/2011-05-02-options.mdown
+++ b/_posts/docs/2011-05-02-options.mdown
@@ -91,7 +91,7 @@ CSS properties applied to the container. Masonry uses relative/absolute position
   <dd class="default"><code><span class="mi">0</span></code></dd>
 </dl>
 
-Adds additional spacing between columns.
+Adds additional spacing, in pixels, between columns.
 
 [See Demo: Gutters](../demos/gutters.html).
 


### PR DESCRIPTION
See discussion at https://github.com/desandro/masonry/issues/589
