### PR TITLE
Point masonry main file to dist/masonry.pkgd.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "masonry",
   "version": "3.1.5",
   "description": "Cascading grid layout library",
-  "main": "masonry.js",
+  "main": "dist/masonry.pkgd.js",
   "dependencies": {
     "get-size": "desandro/get-size#>=1.1.4 <2.0",
     "outlayer": "^1.2.0"


### PR DESCRIPTION
This is needed for Meteor bower support.
