### PR TITLE
Fix "eventie" helper used with requireJS

### DIFF
--- a/dist/masonry.pkgd.js
+++ b/dist/masonry.pkgd.js
@@ -218,7 +218,7 @@ var eventie = {
 
 if ( typeof define === 'function' && define.amd ) {
   // AMD
-  define( 'eventie/eventie',eventie );
+  define( 'eventie/eventie', function() { return eventie; } );
 } else if ( typeof exports === 'object' ) {
   // CommonJS
   module.exports = eventie;


### PR DESCRIPTION
Fix "eventie" helper used with requireJS :
To use Masonry with RequireJS, when we define a module, we can't define this module with an object because it's return null in other module definition like 'Outlayer'. To solve this error, we will pass a function to define() and return this object properly. This approach is claimed by requireJS documentation. My RequireJS version is 2.1.11.