### PR TITLE
Getting the correct first visible item

### DIFF
--- a/masonry.js
+++ b/masonry.js
@@ -60,7 +60,7 @@
     this.getContainerWidth();
     // if columnWidth is 0, default to outerWidth of first item
     if ( !this.columnWidth ) {
-      var firstItem = this.items[0];
+      var firstItem = this.items.find(function(item) {return !item.isIgnored;});
       var firstItemElem = firstItem && firstItem.element;
       // columnWidth fall back to item of first element
       this.columnWidth = firstItemElem && getSize( firstItemElem ).outerWidth ||


### PR DESCRIPTION
This is a quick fix for rightly selecting the first element that is not  marked ignored,

I've built a simple extension that enables filtering items, but it was not behaving correctly when the first item was filtered-out (ignored), ... please check here, https://github.com/websemantics/masonry-plus/issues/1

Thank you for the great work on this plugin,
