### PR TITLE
Fix getSize measurement bug, solves issue #783

### DIFF
--- a/dist/masonry.pkgd.js
+++ b/dist/masonry.pkgd.js
@@ -391,7 +391,12 @@ function setup() {
   body.appendChild( div );
   var style = getStyle( div );
 
-  getSize.isBoxSizeOuter = isBoxSizeOuter = getStyleSize( style.width ) == 200;
+  //style.width doesn't return 200 on Chrome using a 67% zoom level, but 199.992, which caused the bug. On all other zoom levels it return 200 as expected.
+  //Rounding it to the 1st decimal solves the bug, but maybe there is a cleaner version. Im not sure why this happens
+  var widthStyleSize=getStyleSize( style.width );
+  widthStyleSize=Math.round(widthStyleSize*10)/10; //199.992 -> 200
+  
+  getSize.isBoxSizeOuter = isBoxSizeOuter = widthStyleSize == 200;
   body.removeChild( div );
 
 }


### PR DESCRIPTION
Currently the Masonry layout breaks when using a zoom level of 67% on Safari and Chrome browsers. This small fix solves the problem