### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ See [masonry.desandro.com](https://masonry.desandro.com) for complete docs and d
 
 ### CDN
 
-Link directly to Masonry files on [unpkg](https://unpkg.com/).
+Link directly to Masonry files on [jsDelivr](https://www.jsdelivr.com/package/npm/masonry-layout):
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/masonry-layout@4/dist/masonry.pkgd.js"></script>
+<!-- or -->
+<script src="https://cdn.jsdelivr.net/npm/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+```
+
+Or on [unpkg](https://unpkg.com/):
 
 ``` html
 <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.js"></script>


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/masonry-layout) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability. We also have detailed usage stats for project maintainers.