### PR TITLE
Ensuring that masonry will only be initialized on the client side (SSR fix)

### DIFF
--- a/masonry.js
+++ b/masonry.js
@@ -6,7 +6,7 @@
  * by David DeSandro
  */
 
-( function( window, factory ) {
+(typeof window !== 'undefined') && ( function( window, factory ) {
   // universal module definition
   /* jshint strict: false */ /*globals define, module, require */
   if ( typeof define == 'function' && define.amd ) {


### PR DESCRIPTION
Since JS frameworks / libraries + SSR (Server-Server-Rendering) got pretty popular it would be great to make this plugin work with SSR projects. This condition ensures that the masonry plugin will only load within the browser and not on the server and eventually crash it by resulting in a ReferenceError for the window object.

an older reference issue I found where other people experienced this: https://github.com/desandro/masonry/issues/966